### PR TITLE
Update proxy.ts

### DIFF
--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -670,7 +670,7 @@ export class Proxy implements IProxy {
           process.nextTick(sem.leave.bind(sem));
           self.sslServers[hostname] = {
             // @ts-ignore
-            port: self.sslServers[wildcardHost],
+            port: self.sslServers[wildcardHost].port,
           };
           return makeConnection(self.sslServers[hostname].port);
         }


### PR DESCRIPTION
Port property needs to be a number, but is current object.  Should fix this issue:
[https://github.com/joeferner/node-http-mitm-proxy/issues/248](https://github.com/joeferner/node-http-mitm-proxy/issues/248)